### PR TITLE
Corrected referenced link and found a simple typo

### DIFF
--- a/src/main/book/en/ch03.xml
+++ b/src/main/book/en/ch03.xml
@@ -14,15 +14,15 @@
 	your tests, as well as other assets such as Test Plan, Custom Fields, Reports 
 	and Baselines.</para>
 	
-	<para>We will see how to configure our envinronment for this integration 
+	<para>We will see how to configure our environment for this integration 
 	throughout the next chapters. While it is good to have a written 
 	explanation on how this integration works, probably it is a lot easier to 
 	understand how it works with a hands-on. The rest of this guide explains 
 	how to configure Jenkins and TestLink to run automated tests from a sample  
 	test project. This test project is a Java project that uses Maven and  
 	TestNG and you can download the source code from 
-	<ulink url="https://github.com/kinow/jenkins-testlink-plugin-tutorial">
-	https://github.com/kinow/jenkins-testlink-plugin-tutorial</ulink> (as well 
+	<ulink url="https://github.com/tupilabs/jenkins-testlink-plugin-tutorial">
+	https://github.com/tupilabs/jenkins-testlink-plugin-tutorial</ulink> (as well 
 	as the DocBook source for this book).</para>
 	
 	<para>The current version of Jenkins TestLink Plug-in while this book is 

--- a/src/main/book/es/ch03.xml
+++ b/src/main/book/es/ch03.xml
@@ -44,8 +44,8 @@
 	y  <application>TestLink</application> para ejecutar pruebas automatizadas de un 
 	proyecto de pruebas modelo. Este es un proyecto JAVA que utiliza 
 	<application>Maven</application> y <application>TestNG</application>. Se puede descargalo de
-	<ulink url="https://github.com/kinow/jenkins-testlink-plugin-the-definitive-guide/blob/master/sample-test-project.tar.gz?raw=true">
-	https://github.com/kinow/jenkins-testlink-plugin-the-definitive-guide/blob/master/sample-test-project.tar.gz?raw=true</ulink>.</para>
+	<ulink url="https://github.com/tupilabs/jenkins-testlink-plugin-tutorial">
+	https://github.com/tupilabs/jenkins-testlink-plugin-tutorial</ulink>.</para>
 	
 	<para><application>Jenkins TestLink Plug-in</application> está licenciado bajo la licencia
 	<acronym>MIT</acronym> License y su código se encuentra alojado en github - 

--- a/src/main/book/fr/ch03.xml
+++ b/src/main/book/fr/ch03.xml
@@ -47,8 +47,8 @@
 	a sample test project. This test project is a Java project that uses 
 	<application>Maven</application> and <application>TestNG</application>, you 
 	can download it from 
-	<ulink url="https://github.com/kinow/jenkins-testlink-plugin-the-definitive-guide/blob/master/sample-test-project.tar.gz?raw=true">
-	https://github.com/kinow/jenkins-testlink-plugin-the-definitive-guide/blob/master/sample-test-project.tar.gz?raw=true</ulink>.</para>
+	<ulink url="https://github.com/tupilabs/jenkins-testlink-plugin-tutorial">
+	https://github.com/tupilabs/jenkins-testlink-plugin-tutorial</ulink>.</para>
 	
 	<para><application>Jenkins TestLink Plug-in</application> is licensed under the 
 	<acronym>MIT</acronym> License and its 

--- a/src/main/book/fr/ch03.xml
+++ b/src/main/book/fr/ch03.xml
@@ -38,7 +38,7 @@
 	well as uploading any attachments defined by you. This integration is 
 	achieved with <application>Jenkins TestLink Plugin</application>.</para>
 	
-	<para>We will see how to configure our envinronment for this integration 
+	<para>We will see how to configure our environment for this integration 
 	throughout the next chapters. While it is good to have a good written 
 	explanation on how this integration works, probably it is a lot easier 
 	to understand how it works with a hands-on. The rest of this guide 


### PR DESCRIPTION
Assume the repository has moved and used to live in https://github.com/kinow/jenkins-testlink-plugin-tutorial

Have not checked so far if same 404 exists in other translations of the tutorial.

Cheers, Oliver
